### PR TITLE
Add user-agent logging

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-/node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - 0.8
 before_script:
+  - npm update -g npm
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - 0.8
+before_install:
+  - npm install -g npm
 before_script:
-  - npm update -g npm
   - npm install -g grunt-cli

--- a/lib/winston-request-logger.js
+++ b/lib/winston-request-logger.js
@@ -10,6 +10,7 @@
 var url = require('url')
   , events = require('events')
   , colors = require('colors')
+  , useragent = require('useragent')
   , Logger = {};
 
 /**
@@ -58,7 +59,8 @@ Logger.create = function (logger, format) {
                 ':method': req.method,
                 ':responseTime': (new Date() - startTime),
                 ':url\\[([a-z]+)\\]': function (str, segment) { return requestedUrl[segment]; },
-                ':ip': req.headers['x-forwarded-for'] || req.ip || req.connection.remoteAddress
+                ':ip': req.headers['x-forwarded-for'] || req.ip || req.connection.remoteAddress,
+                ':userAgent': useragent.parse(req.headers['user-agent']).toString()
             };
 
             // Do the work expected
@@ -72,7 +74,8 @@ Logger.create = function (logger, format) {
                     status: ':statusCode',
                     method: ':method',
                     url: ':url[pathname]',
-                    response_time: ':responseTime'
+                    response_time: ':responseTime',
+                    user_agent: ':userAgent'
                 };
             }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "colors": "*",
-    "useragent": "^2.0.9",
+    "useragent": "*",
     "winston": "*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
   ],
   "main": "lib/winston-request-logger",
   "engines": {
-    "node": ">= 0.6.0",
-    "npm": ">= 1.4.0"
+    "node": ">= 0.6.0"
   },
   "scripts": {
     "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "winston": "*",
-    "colors": "*"
+    "colors": "*",
+    "useragent": "^2.0.9",
+    "winston": "*"
   },
   "devDependencies": {
     "grunt-simple-mocha": "~0.4.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   ],
   "main": "lib/winston-request-logger",
   "engines": {
-    "node": ">= 0.6.0"
+    "node": ">= 0.6.0",
+    "npm": ">= 1.4.0"
   },
   "scripts": {
     "test": "grunt test"

--- a/test/winston-request-logger_test.js
+++ b/test/winston-request-logger_test.js
@@ -36,6 +36,7 @@ describe('winston-request-logger', function () {
                 data.should.have.property('method');
                 data.should.have.property('url');
                 data.should.have.property('response_time');
+                data.should.have.property('user_agent');
                 done();
             });
 


### PR DESCRIPTION
This uses the [`useragent` NPM module](https://github.com/3rd-Eden/useragent) to parse a user's browser agent in the request. Tests have been updated to expect this as a default option.
