### PR TITLE
Add support for custom log levels

### DIFF
--- a/lib/winston-request-logger.js
+++ b/lib/winston-request-logger.js
@@ -88,14 +88,21 @@ Logger.create = function (logger, format) {
                 }
             }
 
+            // Use custom log method if provided
+            var level = 'info';
+            if (data.level) {
+                level = data.level;
+                delete data.level;
+            }
+
             // If we have a `message` key, we'll treat it as special and pass
             // it into Winston correctly.
             if (data.message) {
                 var message = data.message;
                 delete data.message;
-                return logger.info(message, data);
+                return logger[level](message, data);
             }
-            logger.info(data);
+            logger[level](data);
         };
 
         next();


### PR DESCRIPTION
- Updated tests for newer winston
  - The event triggered on a log is now 'logging' and requires a transport defined to trigger the event on a log
- Added test for custom log level
